### PR TITLE
Use v1.12 of the eidas-psd2-sdk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 		<apache.httpasyncclient.version>4.1.4</apache.httpasyncclient.version>
 		<lombok.version>1.18.10</lombok.version>
 		<nimbusds.version>7.3</nimbusds.version>
-		<eidas.sdk.version>1.11</eidas.sdk.version>
+		<eidas.sdk.version>1.12</eidas.sdk.version>
 	</properties>
 
 	<dependencyManagement>


### PR DESCRIPTION
- This will mean we correctly generate and parse qcTypes in EIDAS certs